### PR TITLE
fix: rename Repository#notes to #entries

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    textrepo (0.3.0)
+    textrepo (0.4.0)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -10,12 +10,16 @@ in the repository operates with the associated timestamp.
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'textrepo', github: 'mnbi/textrepo', branch: 'main'
+gem 'textrepo'
 ```
 
 And then execute:
 
     $ bundle install
+
+Or install it yourself as:
+
+    $ gem install textrepo
 
 ## Usage
 

--- a/examples/rbnotes/lib/rbnotes/commands/list.rb
+++ b/examples/rbnotes/lib/rbnotes/commands/list.rb
@@ -7,7 +7,7 @@ module Rbnotes
       max = (args.shift || @row - 3).to_i
 
       @repo = Textrepo.init(conf)
-      notes = @repo.notes.sort{|a, b| b <=> a}
+      notes = @repo.entries.sort{|a, b| b <=> a}
       notes[0, max].each { |timestamp_str|
         puts make_headline(timestamp_str)
       }

--- a/lib/textrepo/file_system_repository.rb
+++ b/lib/textrepo/file_system_repository.rb
@@ -8,7 +8,7 @@ module Textrepo
     FAVORITE_REPOSITORY_NAME = 'notes'
     FAVORITE_EXTNAME = 'md'
 
-    # `config` must be a Hash object.  It should hold the follwoing
+    # `conf` must be a Hash object.  It must hold the follwoing
     # values:
     #
     # - :repository_type (:file_system)
@@ -17,17 +17,17 @@ module Textrepo
     # - :default_extname => extname for a file stored into in the repository
     #
     # The root path of the repository looks like the following:
-    # - config[:repository_base]/config[:repository_name]
+    # - conf[:repository_base]/conf[:repository_name]
     # 
     # Default values are set when `repository_name` and `default_extname`
-    # were not defined in `config`.
-    def initialize(config)
+    # were not defined in `conf`.
+    def initialize(conf)
       super
-      base = config[:repository_base]
+      base = conf[:repository_base]
       @name ||= FAVORITE_REPOSITORY_NAME
       @path = File.expand_path("#{name}", base)
       FileUtils.mkdir_p(@path)
-      @extname = config[:default_extname] || FAVORITE_EXTNAME
+      @extname = conf[:default_extname] || FAVORITE_EXTNAME
     end
 
     #
@@ -86,8 +86,8 @@ module Textrepo
       content
     end
 
-    # Finds notes those timestamp matches the specified pattern.
-    def notes(stamp_pattern = nil)
+    # Finds entries of text those timestamp matches the specified pattern.
+    def entries(stamp_pattern = nil)
       results = []
 
       case stamp_pattern.to_s.size
@@ -97,13 +97,13 @@ module Textrepo
           results << stamp.to_s
         end
       when 0, "yyyymoddhhmiss".size, "yyyymodd".size
-        results += find_notes(stamp_pattern)
+        results += find_entries(stamp_pattern)
       when 4                    # "yyyy" or "modd"
         pat = nil
         # The following distinction is practically correct, but not
         # perfect.  It simply assumes that a year is greater than
-        # 1231.  For, a year before 1232 is too old for us to create a
-        # note (I believe...).
+        # 1231.  For, a year before 1232 is too old for us to create
+        # any text (I believe...).
         if stamp_pattern.to_i > 1231
           # yyyy
           pat = stamp_pattern
@@ -111,7 +111,7 @@ module Textrepo
           # modd
           pat = "*#{stamp_pattern}"
         end
-        results += find_notes(pat)
+        results += find_entries(pat)
       end
 
       results
@@ -130,15 +130,15 @@ module Textrepo
       }
     end
 
-    def timestamp_str(notepath)
-      File.basename(notepath).delete_suffix(".#{@extname}")
+    def timestamp_str(text_path)
+      File.basename(text_path).delete_suffix(".#{@extname}")
     end
 
     def exist?(timestamp)
       FileTest.exist?(abspath(timestamp))
     end
 
-    def find_notes(stamp_pattern)
+    def find_entries(stamp_pattern)
       Dir.glob("#{@path}/**/#{stamp_pattern}*.#{@extname}").map { |e|
         timestamp_str(e)
       }

--- a/lib/textrepo/repository.rb
+++ b/lib/textrepo/repository.rb
@@ -2,9 +2,9 @@ module Textrepo
   class Repository
     attr_reader :type, :name
 
-    def initialize(config)
-      @type = config[:repository_type]
-      @name = config[:repository_name]
+    def initialize(conf)
+      @type = conf[:repository_type]
+      @name = conf[:repository_name]
     end
 
     # Stores text data into the repository with the specified timestamp.
@@ -23,8 +23,8 @@ module Textrepo
     # the timestamp.  Returns an array which contains the deleted text.
     def delete(timestamp); []; end
 
-    # Finds all notes those have timestamps which mathes the specified
-    # pattern of timestamp.  Returns an array which contains
+    # Finds all entries of text those have timestamps which mathes the
+    # specified pattern of timestamp.  Returns an array which contains
     # timestamps.  A pattern must be one of the following:
     #
     #     - yyyymoddhhmiss_lll : whole stamp
@@ -34,25 +34,29 @@ module Textrepo
     #     - yyyy               : year only
     #     - modd               : month and day
     #
-    # If `stamp_pattern` is omitted, the recent notes will be listed.
-    # Then, how many notes are listed depends on the implementaiton of
-    # the concrete repository class.
-    def notes(stamp_pattern = nil); []; end
+    # If `stamp_pattern` is omitted, the recent entries will be listed.
+    # Then, how many entries are listed depends on the implementaiton
+    # of the concrete repository class.
+    def entries(stamp_pattern = nil); []; end
 
   end
 
   require_relative 'file_system_repository'
 
-  def init(config)
-    type = config[:repository_type]
-    cname = type.to_s.split(/_/).map(&:capitalize).join + "Repository"
-    repo_generator = "#{cname}.new(config)"
-
-    begin
-      eval repo_generator
-    rescue 
+  # Returns an instance which derived from Textrepo::Repository class.
+  # `conf` must be a Hash object which has a value of
+  # `:repository_type` and `:repository_name` at least.  Some concrete
+  # class derived from Textrepo::Repository may require more key-value
+  # pairs in `conf`.
+  def init(conf)
+    type = conf[:repository_type]
+    klass_name = type.to_s.split(/_/).map(&:capitalize).join + "Repository"
+    if Textrepo.const_defined?(klass_name)
+      klass = Textrepo.const_get(klass_name, false)
+    else
       raise UnknownRepoTypeError, type.nil? ? "(nil)" : type
     end
+    klass.new(conf)
   end
   module_function :init
 end

--- a/lib/textrepo/version.rb
+++ b/lib/textrepo/version.rb
@@ -1,3 +1,3 @@
 module Textrepo
-  VERSION = '0.3.0'
+  VERSION = '0.4.0'
 end

--- a/test/textrepo_file_system_repository_test.rb
+++ b/test/textrepo_file_system_repository_test.rb
@@ -288,54 +288,41 @@ class TextrepoFileSystemRepositoryTest < Minitest::Test
   end
 
   # for `notes(stamp_pattern)`
-  def test_it_can_get_a_list_of_notes_without_args
+  def test_it_can_get_a_list_of_text_without_args
     repo = Textrepo::FileSystemRepository.new(@config_ro)
-    notes = repo.notes
-    refute_nil notes
-    assert_equal 6, notes.size
-    assert notes.include?("20200101010000")
-    assert notes.include?("20200101010001")
-    assert notes.include?("20200101010002")
+    entries = repo.entries
+    refute_nil entries
+    assert_equal 6, entries.size
+    assert entries.include?("20200101010000")
+    assert entries.include?("20200101010001")
+    assert entries.include?("20200101010002")
   end
 
   def test_it_can_get_a_list_with_a_full_timestamp_str
-    repo = Textrepo::FileSystemRepository.new(@config_ro)
-    stamp_str = "2020-01-01 01:00:00".delete("- :")
-    notes = repo.notes(stamp_str)
-    assert_equal 2, notes.size
-    assert notes.include?(stamp_str)
+    assert_entries_pattern("2020-01-01 01:00:00".delete("- :"), 2)
   end
 
   def test_it_can_get_a_list_with_a_yyyymoddhhmiss_pattern
-    repo = Textrepo::FileSystemRepository.new(@config_ro)
-    pattern = "2020-01-01 01:00:01".delete("- :")
-    notes = repo.notes(pattern)
-    assert_equal 2, notes.size
-    assert notes.reduce(false) {|r, e| r ||= e.include?(pattern)}
+    assert_entries_pattern("2020-01-01 01:00:01".delete("- :"), 2)
   end
 
   def test_it_can_get_a_list_with_a_yyyymodd_pattern
-    repo = Textrepo::FileSystemRepository.new(@config_ro)
-    pattern = "2020-01-01".delete("-")
-    notes = repo.notes(pattern)
-    assert_equal 6, notes.size
-    assert notes.reduce(false) {|r, e| r ||= e.include?(pattern)}
+    assert_entries_pattern("2020-01-01".delete("-"), 6)
   end
 
   def test_it_can_get_a_list_with_a_yyyy_pattern
-    repo = Textrepo::FileSystemRepository.new(@config_ro)
-    pattern = "2020"
-    notes = repo.notes(pattern)
-    assert_equal 6, notes.size
-    assert notes.reduce(false) {|r, e| r ||= e.include?(pattern)}
+    assert_entries_pattern("2020", 6)
   end
 
   def test_it_can_get_a_list_with_a_modd_pattern
-    repo = Textrepo::FileSystemRepository.new(@config_ro)
-    pattern = "0101"
-    notes = repo.notes(pattern)
-    assert_equal 6, notes.size
-    assert notes.reduce(false) {|r, e| r ||= e.include?(pattern)}
+    assert_entries_pattern("0101", 6)
   end
 
+  private
+  def assert_entries_pattern(pattern, num)
+    repo = Textrepo::FileSystemRepository.new(@config_ro)
+    entries = repo.entries(pattern)
+    assert_equal num, entries.size
+    assert entries.reduce(false) {|r, e| r ||= e.include?(pattern)}
+  end
 end


### PR DESCRIPTION
- bump minor version because of API change (rename a public method)
- modify and refactor tests to fit the rename update install
- instruction in README.md since I would regist this package into
  "rubygems.org".

And some refactor was also done.  This commit will fix #11.