### PR TITLE
fix: move unsuitable method of Timestamp into FileSystemRepository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,56 @@
-/.bundle/
-/.yardoc
-/_yardoc/
+*.gem
+*.rbc
+/.config
 /coverage/
-/doc/
+/InstalledFiles
 /pkg/
 /spec/reports/
+/spec/examples.txt
+/test/tmp/
+/test/version_tmp/
 /tmp/
+
+# Used by dotenv library to load environment variables.
+# .env
+
+# Ignore Byebug command history file.
+.byebug_history
+
+## Specific to RubyMotion:
+.dat*
+.repl_history
+build/
+*.bridgesupport
+build-iPhoneOS/
+build-iPhoneSimulator/
+
+## Specific to RubyMotion (use of CocoaPods):
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+#
+# vendor/Pods/
+
+## Documentation cache and generated files:
+/.yardoc/
+/_yardoc/
+/doc/
+/rdoc/
+
+## Environment normalization:
+/.bundle/
+/vendor/bundle
+/lib/bundler/man/
+
+# for a library or gem, you might want to ignore these files since the code is
+# intended to run in multiple environments; otherwise, check them in:
+# Gemfile.lock
+# .ruby-version
+# .ruby-gemset
+
+# unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
+.rvmrc
+
+# Used by RuboCop. Remote config files pulled in from inherit_from directive.
+# .rubocop-https?--*

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    textrepo (0.4.1)
+    textrepo (0.4.2)
 
 GEM
   remote: https://rubygems.org/

--- a/Rakefile
+++ b/Rakefile
@@ -35,3 +35,12 @@ end
 task :clobber => :clean_sandbox
 CLOBBER << 'test/fixtures/notes'
 CLOBBER << 'test/fixtures/test_repo'
+
+require "rdoc/task"
+
+RDoc::Task.new do |rdoc|
+  rdoc.generator = "ri"
+  rdoc.rdoc_dir = "doc"
+  rdoc.rdoc_files.include("lib/**/*.rb")
+  rdoc.markup = "markdown"
+end

--- a/lib/textrepo/timestamp.rb
+++ b/lib/textrepo/timestamp.rb
@@ -1,11 +1,17 @@
 module Textrepo
+  ##
+  # Timstamp is generated from a Time object.  It converts a time to
+  # string in the obvious format, such "20201023122400".
+  #
   class Timestamp
     include Comparable
 
     attr_reader :time, :suffix
 
-    # time: a Time instance
-    # suffix: an Integer instance
+    ##
+    # :call-seq:
+    #   new(Time, Integer = nil)
+    #
     def initialize(time, suffix = nil)
       @time = time
       @suffix = suffix
@@ -20,26 +26,29 @@ module Textrepo
       result == 0 ? (sfx <=> osfx) : result
     end
 
+    ##
+    # Generate an obvious time string.
+    #
+    # ```
     #  %Y   %m %d %H %M %S  suffix
     # "2020-12-30 12:34:56  (0 | nil)" => "20201230123456"
     # "2020-12-30 12:34:56  (7)"       => "20201230123456_007"
+    # ```
+    #
     def to_s
       s = @time.strftime("%Y%m%d%H%M%S")
       s += "_#{"%03u" % @suffix}" unless @suffix.nil? || @suffix == 0
       s
     end
 
-    #  %Y   %m %d %H %M %S  suffix        %Y/%m/  %Y%m%d%H%M%S %L
-    # "2020-12-30 12:34:56  (0 | nil)" => "2020/12/20201230123456"
-    # "2020-12-30 12:34:56  (7)"       => "2020/12/20201230123456_007"
-    def to_pathname
-      @time.strftime("%Y/%m/") + self.to_s
-    end
-
     class << self
+      ##
+      # ```
       #  yyyymoddhhmiss sfx      yyyy    mo    dd    hh    mi    ss    sfx
       # "20201230123456"     => "2020", "12", "30", "12", "34", "56"
       # "20201230123456_789" => "2020", "12", "30", "12", "34", "56", "789"
+      # ```
+      #
       def split_stamp(stamp_str)
         #    yyyy  mo    dd    hh    mi      ss      sfx
         a = [0..3, 4..5, 6..7, 8..9, 10..11, 12..13, 15..17].map {|r| stamp_str[r]}
@@ -51,13 +60,6 @@ module Textrepo
         Timestamp.new(Time.new(year, mon, day, hour, min, sec), sfx)
       end
 
-      #                      (-2)
-      #  0       8           |(-1)
-      #  V       V           VV
-      # "2020/12/20201230123456" => "2020-12-30 12:34:56"
-      def parse_pathname(pathname)
-        parse_s(pathname[8..-1])
-      end
     end
   end
 end

--- a/lib/textrepo/version.rb
+++ b/lib/textrepo/version.rb
@@ -1,3 +1,3 @@
 module Textrepo
-  VERSION = '0.4.1'
+  VERSION = '0.4.2'
 end

--- a/test/textrepo_file_system_repository_test.rb
+++ b/test/textrepo_file_system_repository_test.rb
@@ -22,12 +22,13 @@ class TextrepoFileSystemRepositoryTest < Minitest::Test
 
     repo_rw_path = File.expand_path(@config_rw[:repository_name],
                                     @config_rw[:repository_base])
-    dst = File.expand_path(stamp.to_pathname + '.md', repo_rw_path)
-    dst_sfx = File.expand_path(stmp_sfx.to_pathname + '.md', repo_rw_path)
+    dst = File.expand_path(timestamp_to_pathname(stamp) + '.md', repo_rw_path)
+    dst_sfx = File.expand_path(timestamp_to_pathname(stmp_sfx) + '.md',
+                               repo_rw_path)
 
     repo_ro_path = File.expand_path(@config_ro[:repository_name],
                                     @config_ro[:repository_base])
-    src = File.expand_path(stamp.to_pathname + '.md', repo_ro_path)
+    src = File.expand_path(timestamp_to_pathname(stamp) + '.md', repo_ro_path)
 
     FileUtils.mkdir_p(File.dirname(dst))
     FileUtils.copy_file(src, dst)
@@ -180,7 +181,7 @@ class TextrepoFileSystemRepositoryTest < Minitest::Test
     new_stamp = repo_rw.update(org_stamp, text)
     refute_equal org_stamp, new_stamp
 
-    newpath = File.expand_path(new_stamp.to_pathname + '.md', repo_rw.path)
+    newpath = File.expand_path(timestamp_to_pathname(new_stamp) + '.md', repo_rw.path)
     content = nil
     File.open(newpath, 'r') { |f|
       content = f.readlines(chomp: true)
@@ -197,7 +198,7 @@ class TextrepoFileSystemRepositoryTest < Minitest::Test
     new_stamp = repo_rw.update(org_stamp, text)
     refute_equal org_stamp, new_stamp
 
-    newpath = File.expand_path(new_stamp.to_pathname + '.md', repo_rw.path)
+    newpath = File.expand_path(timestamp_to_pathname(new_stamp) + '.md', repo_rw.path)
     content = nil
     File.open(newpath, 'r') { |f|
       content = f.readlines(chomp: true)
@@ -241,7 +242,7 @@ class TextrepoFileSystemRepositoryTest < Minitest::Test
     repo_rw = Textrepo::FileSystemRepository.new(@config_rw)
 
     stamp = Textrepo::Timestamp.new(Time.new(2020, 1, 1, 1, 0, 0))
-    path = File.expand_path(stamp.to_pathname + '.md', repo_rw.path)
+    path = File.expand_path(timestamp_to_pathname(stamp) + '.md', repo_rw.path)
 
     expected = []
     File.open(path, 'r') { |f| expected = f.readlines(chomp: true) }
@@ -257,7 +258,7 @@ class TextrepoFileSystemRepositoryTest < Minitest::Test
 
     suffix = 88
     stamp = Textrepo::Timestamp.new(Time.new(2020, 1, 1, 1, 0, 0), suffix)
-    path = File.expand_path(stamp.to_pathname + '.md', repo_rw.path)
+    path = File.expand_path(timestamp_to_pathname(stamp) + '.md', repo_rw.path)
 
     expected = []
     File.open(path, 'r') { |f| expected = f.readlines(chomp: true) }
@@ -324,5 +325,10 @@ class TextrepoFileSystemRepositoryTest < Minitest::Test
     entries = repo.entries(pattern)
     assert_equal num, entries.size
     assert entries.reduce(false) {|r, e| r ||= e.include?(pattern)}
+  end
+
+  def timestamp_to_pathname(timestamp)
+    yyyy, mo = Textrepo::Timestamp.split_stamp(timestamp.to_s)[0..1]
+    File.join(yyyy, mo, timestamp.to_s)
   end
 end

--- a/test/textrepo_timestamp_test.rb
+++ b/test/textrepo_timestamp_test.rb
@@ -56,19 +56,6 @@ class TextrepoTimestampTest < Minitest::Test
     assert_equal '20200201000001_006', stamp.to_s
   end
 
-  def test_it_can_generate_pathname
-    time = Time.new(2020, 1, 1, 0, 0, 2)
-    stamp = Textrepo::Timestamp.new(time)
-    assert_equal '2020/01/20200101000002', stamp.to_pathname
-  end
-
-  def test_it_can_generate_pathname_with_suffix
-    time = Time.new(2020, 2, 1, 0, 0, 2)
-    suffix = 345
-    stamp = Textrepo::Timestamp.new(time, suffix)
-    assert_equal '2020/02/20200201000002_345', stamp.to_pathname
-  end
-
   def test_it_is_comparable
     t0 = Textrepo::Timestamp.new(Time.new(2020, 1, 1, 0, 0, 3))
     t1 = Textrepo::Timestamp.new(Time.new(2020, 1, 1, 0, 0, 4))
@@ -104,21 +91,6 @@ class TextrepoTimestampTest < Minitest::Test
     suffix = 789
     stamp0 = Textrepo::Timestamp.new(time, suffix)
     stamp1 = Textrepo::Timestamp.parse_s(stamp0.to_s)
-    assert_equal stamp0, stamp1
-  end
-
-  def test_it_can_be_generated_from_pathname
-    time = Time.new(2020, 1, 1, 0, 0, 6)
-    stamp0 = Textrepo::Timestamp.new(time)
-    stamp1 = Textrepo::Timestamp.parse_pathname(stamp0.to_pathname)
-    assert_equal stamp0, stamp1
-  end
-
-  def test_it_can_be_generated_from_pathname_with_suffix
-    time = Time.new(2020, 1, 1, 0, 0, 6)
-    suffix = 23
-    stamp0 = Textrepo::Timestamp.new(time, suffix)
-    stamp1 = Textrepo::Timestamp.parse_pathname(stamp0.to_pathname)
     assert_equal stamp0, stamp1
   end
 end

--- a/textrepo.gemspec
+++ b/textrepo.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |spec|
   spec.email         = ["mnbi@users.noreply.github.com"]
 
   spec.summary       = %q{A repository to store text with timestamp.}
-  spec.description   = %q{Textrepo is a repository to store text with timestamp.  It can manage text with the attached timestamp (read/update/delte).}
+  spec.description   = %q{Textrepo is a repository to store text with timestamp.  It can manage text with the attached timestamp (create/read/update/delete).}
   spec.homepage      = "https://github.com/mnbi/textrepo"
   spec.license       = "MIT"
   spec.required_ruby_version = Gem::Requirement.new(">= 2.7.0")


### PR DESCRIPTION
- fix Timestamp and its tests
- add rdoc tasks in Rakefile
- add rdoc comments in some rb files
- modify the description in `textrepo.gemspec`
- replace .gitignore to GitHub generated one