### PR TITLE
fix: FileSystemRepository#entries returns wrong value

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -42,5 +42,4 @@ RDoc::Task.new do |rdoc|
   rdoc.generator = "ri"
   rdoc.rdoc_dir = "doc"
   rdoc.rdoc_files.include("lib/**/*.rb")
-  rdoc.markup = "markdown"
 end

--- a/lib/textrepo/file_system_repository.rb
+++ b/lib/textrepo/file_system_repository.rb
@@ -47,6 +47,9 @@ module Textrepo
     # 
     # Default values are set when `repository_name` and `default_extname`
     # were not defined in `conf`.
+    #
+    # :call-seq:
+    #     new(Rbnotes::Conf or Hash) -> FileSystemRepository
 
     def initialize(conf)
       super
@@ -60,9 +63,9 @@ module Textrepo
     ##
     # Creates a file into the repository, which contains the specified
     # text and is associated to the timestamp.
-
+    #
     # :call-seq:
-    #     create(Timestamp, Array) => Timestamp
+    #     create(Timestamp, Array) -> Timestamp
 
     def create(timestamp, text)
       abs = abspath(timestamp)
@@ -76,9 +79,9 @@ module Textrepo
     ##
     # Reads the file content in the repository.  Then, returns its
     # content.
-
+    #
     # :call-seq:
-    #     read(Timestamp) => Array
+    #     read(Timestamp) -> Array
 
     def read(timestamp)
       abs = abspath(timestamp)
@@ -93,9 +96,9 @@ module Textrepo
     ##
     # Updates the file content in the repository.  A new timestamp
     # will be attached to the text.
-
+    #
     # :call-seq:
-    #     update(Timestamp, Array) => Timestamp
+    #     update(Timestamp, Array) -> Timestamp
 
     def update(timestamp, text)
       raise EmptyTextError if text.empty?
@@ -115,9 +118,9 @@ module Textrepo
 
     ##
     # Deletes the file in the repository.
-
+    #
     # :call-seq:
-    #     delete(Timestamp) => Array
+    #     delete(Timestamp) -> Array
 
     def delete(timestamp)
       abs = abspath(timestamp)
@@ -131,9 +134,9 @@ module Textrepo
 
     ##
     # Finds entries of text those timestamp matches the specified pattern.
-
+    #
     # :call-seq:
-    #     entries(String = nil) => Array
+    #     entries(String = nil) -> Array of Timestamp instances
 
     def entries(stamp_pattern = nil)
       results = []
@@ -142,7 +145,7 @@ module Textrepo
       when "yyyymoddhhmiss_lll".size
         stamp = Timestamp.parse_s(stamp_pattern)
         if exist?(stamp)
-          results << stamp.to_s
+          results << stamp
         end
       when 0, "yyyymoddhhmiss".size, "yyyymodd".size
         results += find_entries(stamp_pattern)
@@ -168,7 +171,7 @@ module Textrepo
     ##
     # Check the existence of text which is associated with the given
     # timestamp.
-
+    #
     # :call-seq:
     #     exist?(Timestamp) -> true or false
 
@@ -205,7 +208,7 @@ module Textrepo
 
     def find_entries(stamp_pattern)
       Dir.glob("#{@path}/**/#{stamp_pattern}*.#{@extname}").map { |e|
-        timestamp_str(e)
+        Timestamp.parse_s(timestamp_str(e))
       }
     end
 

--- a/lib/textrepo/repository.rb
+++ b/lib/textrepo/repository.rb
@@ -27,7 +27,7 @@ module Textrepo
     ##
     # Stores text data into the repository with the specified timestamp.
     # Returns the timestamp.
-
+    #
     # :call-seq:
     #     create(Timestamp, Array) -> Timestamp
 
@@ -36,7 +36,7 @@ module Textrepo
     ##
     # Reads text data from the repository, which is associated to the
     # timestamp.  Returns an array which contains the text.
-
+    #
     # :call-seq:
     #     read(Timestamp) -> Array
 
@@ -45,7 +45,7 @@ module Textrepo
     ##
     # Updates the content with text in the repository, which is
     # associated to the timestamp.  Returns the timestamp.
-
+    #
     # :call-seq:
     #     update(Timestamp, Array) -> Timestamp
 
@@ -54,7 +54,7 @@ module Textrepo
     ##
     # Deletes the content in the repository, which is associated to
     # the timestamp.  Returns an array which contains the deleted text.
-
+    #
     # :call-seq:
     #     delete(Timestamp) -> Array
 
@@ -63,8 +63,8 @@ module Textrepo
     ##
     # Finds all entries of text those have timestamps which mathes the
     # specified pattern of timestamp.  Returns an array which contains
-    # timestamps.  If none of text was found, an empty array would be
-    # returned.
+    # instances of Timestamp.  If none of text was found, an empty
+    # array would be returned.
     #
     #  A pattern must be one of the following:
     #
@@ -78,9 +78,9 @@ module Textrepo
     # If `stamp_pattern` is omitted, the recent entries will be listed.
     # Then, how many entries are listed depends on the implementaiton
     # of the concrete repository class.
-
+    #
     # :call-seq:
-    #     entries(String) -> Array
+    #     entries(String) -> Array of Timestamp instances
 
     def entries(stamp_pattern = nil); []; end
 

--- a/lib/textrepo/version.rb
+++ b/lib/textrepo/version.rb
@@ -1,3 +1,3 @@
 module Textrepo
-  VERSION = '0.4.3'
+  VERSION = '0.4.4'
 end

--- a/test/textrepo_file_system_repository_test.rb
+++ b/test/textrepo_file_system_repository_test.rb
@@ -294,9 +294,18 @@ class TextrepoFileSystemRepositoryTest < Minitest::Test
     entries = repo.entries
     refute_nil entries
     assert_equal 6, entries.size
-    assert entries.include?("20200101010000")
-    assert entries.include?("20200101010001")
-    assert entries.include?("20200101010002")
+    assert entries.include?(Textrepo::Timestamp.parse_s("20200101010000"))
+    assert entries.include?(Textrepo::Timestamp.parse_s("20200101010001"))
+    assert entries.include?(Textrepo::Timestamp.parse_s("20200101010002"))
+  end
+
+  # This test reproduces the issue #25.
+  def test_it_returns_array_of_timestamp_instances
+    repo = Textrepo::FileSystemRepository.new(@config_ro)
+    entries = repo.entries
+    entries.each { |e|
+      assert_instance_of Textrepo::Timestamp, e
+    }
   end
 
   def test_it_can_get_a_list_with_a_full_timestamp_str
@@ -337,7 +346,7 @@ class TextrepoFileSystemRepositoryTest < Minitest::Test
     repo = Textrepo::FileSystemRepository.new(@config_ro)
     entries = repo.entries(pattern)
     assert_equal num, entries.size
-    assert entries.reduce(false) {|r, e| r ||= e.include?(pattern)}
+    assert entries.reduce(false) {|r, e| r ||= e.to_s.include?(pattern)}
   end
 
   def timestamp_to_pathname(timestamp)


### PR DESCRIPTION
- modify to return an array of Timestamp objects
- write a test to reproduce the issue symptom
- fix some tests to adapt this modification
- fix some comments
  - timestamp.rb, Repository.rb, FileSystemRepository.rb
- bump version 0.4.3 -> 0.4.4

This PR will fix #25.