### PR TITLE
fix: modify Repository#update to do nothing against the same text (#28)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 Nothing to record here.
 
+## [0.5.1] - 2020-11-02
+### Changed
+- Fix issue #28.
+  - Modify `Repository#update` to do nothing when the given text is
+    identical to the one in the repository.
+
 ## [0.5.0] - 2020-11-01
 ### Added
 - Add a new API `Repository#search`.

--- a/lib/textrepo/file_system_repository.rb
+++ b/lib/textrepo/file_system_repository.rb
@@ -132,21 +132,25 @@ module Textrepo
     # Updates the file content in the repository.  A new timestamp
     # will be attached to the text.
     #
+    # See the documentation of Repository#update to know about errors
+    # and constraints of this method.
+    #
     # :call-seq:
     #     update(Timestamp, Array) -> Timestamp
 
     def update(timestamp, text)
       raise EmptyTextError if text.empty?
-      org_abs = abspath(timestamp)
-      raise MissingTimestampError, timestamp unless FileTest.exist?(org_abs)
+      raise MissingTimestampError, timestamp unless exist?(timestamp)
+
+      # does nothing if given text is the same in the repository one
+      return timestamp if read(timestamp) == text
 
       # the text must be stored with the new timestamp
       new_stamp = Timestamp.new(Time.now)
-      new_abs = abspath(new_stamp)
-      write_text(new_abs, text)
+      write_text(abspath(new_stamp), text)
 
-      # delete the original file in the repository
-      FileUtils.remove_file(org_abs)
+      # delete the original text file in the repository
+      FileUtils.remove_file(abspath(timestamp))
 
       new_stamp
     end

--- a/lib/textrepo/repository.rb
+++ b/lib/textrepo/repository.rb
@@ -43,8 +43,17 @@ module Textrepo
     def read(timestamp); []; end
 
     ##
-    # Updates the content with text in the repository, which is
-    # associated to the timestamp.  Returns the timestamp.
+    # Updates the content with given text in the repository, which is
+    # associated to the given timestamp.  Returns the timestamp newly
+    # generated during the execution.
+    #
+    # If the given Timestamp is not existed as a Timestamp attached to
+    # text in the repository, raises MissingTimestampError.
+    #
+    # If the given text is empty, raises EmptyTextError.
+    #
+    # If the given text is identical to the text in the repository,
+    # does nothing.  Returns the given timestamp itself.
     #
     # :call-seq:
     #     update(Timestamp, Array) -> Timestamp

--- a/lib/textrepo/version.rb
+++ b/lib/textrepo/version.rb
@@ -1,3 +1,3 @@
 module Textrepo
-  VERSION = '0.5.0'
+  VERSION = '0.5.1'
 end

--- a/test/textrepo_file_system_repository_test.rb
+++ b/test/textrepo_file_system_repository_test.rb
@@ -237,6 +237,18 @@ class TextrepoFileSystemRepositoryTest < Minitest::Test
     }
   end
 
+  # issue #28
+  def test_it_does_not_update_with_the_same_text
+    repo_rw = Textrepo::FileSystemRepository.new(@config_rw)
+
+    org_stamp = Textrepo::Timestamp.new(Time.new(2020, 1, 1, 1, 0, 0))
+
+    text = repo_rw.read(org_stamp)
+    new_stamp = repo_rw.update(org_stamp, text)
+
+    assert_equal org_stamp, new_stamp
+  end
+
   # for `delete(timestamp)`
   def test_it_can_delete_text_in_the_repository
     repo_rw = Textrepo::FileSystemRepository.new(@config_rw)


### PR DESCRIPTION
- modify FileSystemRepository#update to do nothing against the same text
- add the description of the new behavior into the `rdoc`
  documentation for Repository#update
- add a test to reproduce issue #28
- add a section for 0.5.1 in CHANGELOG.md
- bump version 0.5.0 -> 0.5.1

This PR will fix #28.