### PR TITLE
fix: accpet "yyyymo" pattern as a Timestamp pattern (#34)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 Nothing to record here.
 
+## [0.5.2] - 2020-11-03
+### Changed
+- Fix issue #34:
+  - fix FileSystemRepository#entries to accept "yyyymo" pattern as a
+    Timestamp pattern.
+- Fix issue #33: fix typo in the doc for FileSystemRepository.new.
+- Fix issue #31: unfriendly error message of Timestamp.parse_s.
+
 ## [0.5.1] - 2020-11-02
 ### Changed
 - Fix issue #28.

--- a/lib/textrepo/file_system_repository.rb
+++ b/lib/textrepo/file_system_repository.rb
@@ -67,9 +67,10 @@ module Textrepo
     # were not defined in `conf`.
     #
     # Be careful to set `:searcher_options`, it must be to specify the
-    # searcher behavior equivalent to `grep` with "-inR".  The default
-    # value for the searcher options is defined for BSD grep (default
-    # grep on macOS), GNU grep, and ripgrep (aka rg).  They are:
+    # searcher behavior equivalent to `grep` with "-inRE".  The
+    # default values for the searcher options is defined for BSD grep
+    # (default grep on macOS), GNU grep, and ripgrep (aka rg).  They
+    # are:
     #
     #   "grep"   => ["-i", "-n", "-R", "-E"]
     #   "egrep"  => ["-i", "-n", "-R"]
@@ -77,7 +78,7 @@ module Textrepo
     #   "gegrep" => ["-i", "-n", "-R"]
     #   "rg"     => ["-S", "-n", "--no-heading", "--color", "never"]
     #
-    # If use those 3 searchers, it is not recommended to set
+    # If use those searchers, it is not recommended to set
     # `:searcher_options`.  The default value works well in
     # `textrepo`.
     #
@@ -186,7 +187,7 @@ module Textrepo
         if exist?(stamp)
           results << stamp
         end
-      when 0, "yyyymoddhhmiss".size, "yyyymodd".size
+      when 0, "yyyymoddhhmiss".size, "yyyymodd".size, "yyyymo".size
         results += find_entries(stamp_pattern)
       when 4                    # "yyyy" or "modd"
         pat = nil

--- a/lib/textrepo/timestamp.rb
+++ b/lib/textrepo/timestamp.rb
@@ -97,8 +97,15 @@ module Textrepo
         begin
           ye, mo, da, ho, mi, se, sfx = split_stamp(stamp_str).map(&:to_i)
           Timestamp.new(Time.new(ye, mo, da, ho, mi, se), sfx)
-        rescue InvalidTimestampStringError, ArgumentError => _
-          raise InvalidTimestampStringError, stamp_str
+        rescue InvalidTimestampStringError, ArgumentError => e
+          emsg = if stamp_str.nil?
+            "(nil)"
+          elsif stamp_str.empty?
+            "(empty string)"
+          else
+            stamp_str
+          end
+          raise InvalidTimestampStringError, emsg
         end
       end
 

--- a/lib/textrepo/version.rb
+++ b/lib/textrepo/version.rb
@@ -1,3 +1,3 @@
 module Textrepo
-  VERSION = '0.5.1'
+  VERSION = '0.5.2'
 end

--- a/test/textrepo_file_system_repository_test.rb
+++ b/test/textrepo_file_system_repository_test.rb
@@ -311,7 +311,7 @@ class TextrepoFileSystemRepositoryTest < Minitest::Test
     assert entries.include?(Textrepo::Timestamp.parse_s("20200101010002"))
   end
 
-  # This test reproduces the issue #25.
+  # [issue #25]
   def test_it_returns_array_of_timestamp_instances
     repo = Textrepo::FileSystemRepository.new(@config_ro)
     entries = repo.entries
@@ -338,6 +338,11 @@ class TextrepoFileSystemRepositoryTest < Minitest::Test
 
   def test_it_can_get_a_list_with_a_modd_pattern
     assert_entries_pattern("0101", 8)
+  end
+
+  # [issue #34]
+  def test_it_can_get_a_list_with_a_yyyymo_pattern
+    assert_entries_pattern("202001", 8)
   end
 
   # for `exist?(timestamp)`

--- a/test/textrepo_timestamp_test.rb
+++ b/test/textrepo_timestamp_test.rb
@@ -105,4 +105,19 @@ class TextrepoTimestampTest < Minitest::Test
       Textrepo::Timestamp.parse_s("not_timestamp_string")
     }
   end
+
+  # [issue #31]
+  def test_parse_s_fais_and_returns_friendly_error_message
+    begin
+      Textrepo::Timestamp.parse_s("") # empty string
+    rescue Textrepo::InvalidTimestampStringError => e
+      assert_includes e.message, "empty"
+    end
+
+    begin
+      Textrepo::Timestamp.parse_s(nil)
+    rescue Textrepo::InvalidTimestampStringError => e
+      assert_includes e.message, "nil"
+    end
+  end
 end


### PR DESCRIPTION
- fix FileSystemRepository#entries to accept "yyyymo" pattern (#34)
- fix typo in the doc for FileSystemRepository.new (#33)
- fix unfriendly error message of Timestamp.parse_s (#31)
- add a section for 0.5.2 in CHANGELOG.md
- bump version 0.5.1 -> 0.5.2

This PR will;
- fix #31,
- fix #33,
- fix #34.