### PR TITLE
feat: change Repository to enumerable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 Nothing to record here.
 
+## [0.5.6] - 2020-11-11
+### Add
+- Change `Repository` to enumerable.
+  - add `#each` method to `Repository`, then include `Enumerable`.
+- Add "-H" option to some searcher default options.
+
 ## [0.5.5] - 2020-11-10
 ### Add
 - Add more methods for `Timestamp` class.

--- a/lib/textrepo/file_system_repository.rb
+++ b/lib/textrepo/file_system_repository.rb
@@ -317,20 +317,7 @@ module Textrepo
     def invoke_searcher_for_entries(searcher, pattern, entries)
       output = []
 
-      num_of_entries = entries.size
-      if num_of_entries == 1
-        # If the search taget is one file, the output needs special
-        # treatment.
-        file = abspath(entries[0])
-        o, s = Open3.capture2(searcher, *find_searcher_options(searcher),
-                              pattern, file)
-        if s.success? && (! o.empty?)
-          output += o.lines.map { |line|
-            # add filename at the beginning of the search result line
-            [file, line.chomp].join(":")
-          }
-        end
-      elsif num_of_entries > LIMIT_OF_FILES
+      if entries.size > LIMIT_OF_FILES
         output += invoke_searcher_for_entries(searcher, pattern, entries[0..(LIMIT_OF_FILES - 1)])
         output += invoke_searcher_for_entries(searcher, pattern, entries[LIMIT_OF_FILES..-1])
       else
@@ -349,14 +336,16 @@ module Textrepo
     end
 
     SEARCHER_OPTS = {
-      # case insensitive, print line number, recursive search, work as egrep
-      "grep"   => ["-i", "-n", "-R", "-E"],
-      # case insensitive, print line number, recursive search
-      "egrep"  => ["-i", "-n", "-R"],
-      # case insensitive, print line number, recursive search, work as gegrep
-      "ggrep"  => ["-i", "-n", "-R", "-E"],
-      # case insensitive, print line number, recursive search
-      "gegrep" => ["-i", "-n", "-R"],
+      # grep option meaning:
+      # - "-i": case insensitive,
+      # - "-n": print line number,
+      # - "-H": print file name,
+      # - "-R": recursive search,
+      # - "-E": work as egrep
+      "grep"   => ["-i", "-n", "-H", "-R", "-E"],
+      "egrep"  => ["-i", "-n", "-H", "-R"],
+      "ggrep"  => ["-i", "-n", "-H", "-R", "-E"],
+      "gegrep" => ["-i", "-n", "-H", "-R"],
       # smart case, print line number, no color
       "rg"     => ["-S", "-n", "--no-heading", "--color", "never"],
     }

--- a/lib/textrepo/repository.rb
+++ b/lib/textrepo/repository.rb
@@ -1,6 +1,8 @@
 module Textrepo
   class Repository
 
+    include Enumerable
+
     ##
     # Repository type.  It specifies which concrete repository class
     # will instantiated.  For example, the type `:file_system` specifies
@@ -125,6 +127,65 @@ module Textrepo
 
     def search(pattern, stamp_pattern = nil); []; end
 
+    ##
+    # Calls the given block once for each pair of timestamp and text
+    # in self, passing those pair as parameter.  Returns the
+    # repository itself.
+    #
+    # If no block is given, an Enumerator is returned.
+
+    def each(&block)
+      if block.nil?
+        entries.lazy.map { |timestamp| pair(timestamp) }.to_enum(:each)
+      else
+        entries.each { |timestamp| yield pair(timestamp) }
+        self
+      end
+    end
+
+    alias each_pair each
+
+    ##
+    # Calls the given block once for each timestamp in self, passing
+    # the timestamp as a parameter.  Returns the repository itself.
+    #
+    # If no block is given, an Enumerator is returned.
+
+    def each_key(&block)
+      if block.nil?
+        entries.to_enum(:each)
+      else
+        entries.each(&block)
+      end
+    end
+
+    alias each_timestamp each_key
+
+    ##
+    # Calls the given block once for each timestamp in self, passing
+    # the text as a parameter.  Returns the repository itself.
+    #
+    # If no block is given, an Enumerator is returned.
+
+    def each_value(&block)
+      if block.nil?
+        entries.lazy.map { |timestamp| read(timestamp) }.to_enum(:each)
+      else
+        entries.each { |timestamp| yield read(timestamp) }
+      end
+    end
+
+    alias each_text each_value
+
+    # :stopdoc:
+
+    private
+
+    def pair(timestamp)
+      [timestamp, read(timestamp)]
+    end
+
+    # :startdoc:
   end
 
   require_relative 'file_system_repository'

--- a/lib/textrepo/version.rb
+++ b/lib/textrepo/version.rb
@@ -1,3 +1,3 @@
 module Textrepo
-  VERSION = '0.5.5'
+  VERSION = '0.5.6'
 end

--- a/test/textrepo_repository_enumerable_test.rb
+++ b/test/textrepo_repository_enumerable_test.rb
@@ -1,0 +1,60 @@
+require "test_helper"
+
+class TextrepoRepositoryEnumerableTest < Minitest::Test
+  def setup
+    @repo = Textrepo.init(CONF_RO)
+  end
+
+  def test_it_can_enumerate_with_each_key
+    keys = []
+    @repo.each_key { |timestamp| keys << timestamp }
+    assert_equal @repo.entries.sort, keys.sort
+  end
+
+  def test_it_returns_enumerator_of_each_key
+    enum = @repo.each_key
+    assert_equal @repo.entries.sort, enum.entries.sort
+  end
+
+  def test_it_can_enumerate_with_each_value
+    all_lines = []
+    @repo.each_value { |text| all_lines.concat(text) }
+
+    assert_equal read_all_lines(@repo).sort, all_lines.sort
+  end
+
+  def test_it_returns_enumerator_of_each_value
+    enum = @repo.each_value
+    assert_equal read_all_lines(@repo).sort, enum.entries.flatten.sort
+  end
+
+  def test_it_can_enumerate_with_each
+    keys = []
+    all_lines = []
+    @repo.each { |timestamp, text|
+      keys << timestamp
+      all_lines.concat(text)
+    }
+
+    entries = @repo.entries
+
+    assert_equal entries.sort, keys.sort
+    assert_equal read_all_lines(@repo).sort, all_lines.sort
+  end
+
+  def test_it_returns_enumerator_of_each
+    enum = @repo.each
+    begin
+      while true
+        pair = enum.next
+        assert_equal @repo.read(pair[0]), pair[1]
+      end
+    rescue StopIteration => _
+    end
+  end
+
+  private
+  def read_all_lines(repo)
+    repo.entries.collect_concat { |stamp| repo.read(stamp) }
+  end
+end


### PR DESCRIPTION
- add "#each", "#each_key", "#each_value" into Repository class
- add "-H" option to some searcher default options
- bump version 0.5.5 -> 0.5.6

This PR will;

- close #44,
- close #45.