### PR TITLE
fix: handle mmdd pattern correctly (FileSystemRepository#entries)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 Nothing to record here.
 
+## [0.5.7] - 2020-11-16
+### Fixed
+- Fix issue #47: mmdd pattern matches incorrectly (`#entries`).
+
 ## [0.5.6] - 2020-11-11
 ### Add
 - Change `Repository` to enumerable.
@@ -27,11 +31,11 @@ Nothing to record here.
     - `Repository#update(timestamp, text, keep_stamp = false)`
 
 ## [0.5.3] - 2020-11-03
-### Changed
+### Fixed
 - Fix issue #38: fix typo in code for FileSystemRepository.
 
 ## [0.5.2] - 2020-11-03
-### Changed
+### Fixed
 - Fix issue #34:
   - fix FileSystemRepository#entries to accept "yyyymo" pattern as a
     Timestamp pattern.
@@ -39,7 +43,7 @@ Nothing to record here.
 - Fix issue #31: unfriendly error message of Timestamp.parse_s.
 
 ## [0.5.1] - 2020-11-02
-### Changed
+### Fixed
 - Fix issue #28.
   - Modify `Repository#update` to do nothing when the given text is
     identical to the one in the repository.

--- a/lib/textrepo/file_system_repository.rb
+++ b/lib/textrepo/file_system_repository.rb
@@ -190,7 +190,7 @@ module Textrepo
           results << stamp
         end
       when 0, "yyyymoddhhmiss".size, "yyyymodd".size, "yyyymo".size
-        results += find_entries(stamp_pattern)
+        results += find_entries("#{stamp_pattern}*")
       when 4                    # "yyyy" or "modd"
         pat = nil
         # The following distinction is practically correct, but not
@@ -199,10 +199,10 @@ module Textrepo
         # any text (I believe...).
         if stamp_pattern.to_i > 1231
           # yyyy
-          pat = stamp_pattern
+          pat = "#{stamp_pattern}*"
         else
           # modd
-          pat = "*#{stamp_pattern}"
+          pat = "????#{stamp_pattern}*"
         end
         results += find_entries(pat)
       end
@@ -270,7 +270,7 @@ module Textrepo
     end
 
     def find_entries(stamp_pattern)
-      Dir.glob("#{@path}/**/#{stamp_pattern}*.#{@extname}").map { |e|
+      Dir.glob("#{@path}/**/#{stamp_pattern}.#{@extname}").map { |e|
         begin
           Timestamp.parse_s(timestamp_str(e))
         rescue InvalidTimestampStringError => _

--- a/lib/textrepo/version.rb
+++ b/lib/textrepo/version.rb
@@ -1,3 +1,3 @@
 module Textrepo
-  VERSION = '0.5.6'
+  VERSION = '0.5.7'
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,7 @@
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require "textrepo"
 
+require 'fileutils'
 require "minitest/autorun"
 
 CONF_RO = {
@@ -15,6 +16,33 @@ CONF_RW = {
   :repository_base => File.expand_path("sandbox", __dir__),
   :default_extname => 'md'
 }
+
+def setup_read_write_repo(conf_rw)
+  # prepare a file into the sandobx repository
+  stamp = Textrepo::Timestamp.new(Time.new(2020, 1, 1, 1, 0, 0))
+  stmp_sfx = Textrepo::Timestamp.new(Time.new(2020, 1, 1, 1, 0, 0), 88)
+
+  repo_rw_path = repo_path(conf_rw)
+  dst = File.expand_path(timestamp_to_pathname(stamp) + '.md', repo_rw_path)
+  dst_sfx = File.expand_path(timestamp_to_pathname(stmp_sfx) + '.md',
+                             repo_rw_path)
+
+  repo_ro_path = repo_path(CONF_RO)
+  src = File.expand_path(timestamp_to_pathname(stamp) + '.md', repo_ro_path)
+
+  FileUtils.mkdir_p(File.dirname(dst))
+  FileUtils.copy_file(src, dst)
+  FileUtils.copy_file(src, dst_sfx)
+end
+
+def repo_path(conf)
+  File.expand_path(conf[:repository_name], conf[:repository_base])
+end
+
+def write_text(path, text)
+  FileUtils.mkdir_p(File.dirname(path))
+  File.open(path, "w") { |f| f.write(text) }
+end
 
 def timestamp_to_pathname(timestamp)
   yyyy, mo = Textrepo::Timestamp.split_stamp(timestamp.to_s)[0..1]

--- a/test/textrepo_file_system_repository_create_test.rb
+++ b/test/textrepo_file_system_repository_create_test.rb
@@ -4,24 +4,7 @@ require 'test_helper'
 class TextrepoFileSystemRepositoryCreateTest < Minitest::Test
   def setup
     @conf_rw = CONF_RW
-
-    # prepare a file into the sandobx repository
-    stamp = Textrepo::Timestamp.new(Time.new(2020, 1, 1, 1, 0, 0))
-    stmp_sfx = Textrepo::Timestamp.new(Time.new(2020, 1, 1, 1, 0, 0), 88)
-
-    repo_rw_path = File.expand_path(@conf_rw[:repository_name],
-                                    @conf_rw[:repository_base])
-    dst = File.expand_path(timestamp_to_pathname(stamp) + '.md', repo_rw_path)
-    dst_sfx = File.expand_path(timestamp_to_pathname(stmp_sfx) + '.md',
-                               repo_rw_path)
-
-    repo_ro_path = File.expand_path(CONF_RO[:repository_name],
-                                    CONF_RO[:repository_base])
-    src = File.expand_path(timestamp_to_pathname(stamp) + '.md', repo_ro_path)
-
-    FileUtils.mkdir_p(File.dirname(dst))
-    FileUtils.copy_file(src, dst)
-    FileUtils.copy_file(src, dst_sfx)
+    setup_read_write_repo(@conf_rw)
   end
 
   def test_it_can_create_a_new_file_in_the_repository

--- a/test/textrepo_file_system_repository_delete_test.rb
+++ b/test/textrepo_file_system_repository_delete_test.rb
@@ -4,24 +4,7 @@ require 'test_helper'
 class TextrepoFileSystemRepositoryDeleteTest < Minitest::Test
   def setup
     @conf_rw = CONF_RW
-
-    # prepare a file into the sandobx repository
-    stamp = Textrepo::Timestamp.new(Time.new(2020, 1, 1, 1, 0, 0))
-    stmp_sfx = Textrepo::Timestamp.new(Time.new(2020, 1, 1, 1, 0, 0), 88)
-
-    repo_rw_path = File.expand_path(@conf_rw[:repository_name],
-                                    @conf_rw[:repository_base])
-    dst = File.expand_path(timestamp_to_pathname(stamp) + '.md', repo_rw_path)
-    dst_sfx = File.expand_path(timestamp_to_pathname(stmp_sfx) + '.md',
-                               repo_rw_path)
-
-    repo_ro_path = File.expand_path(CONF_RO[:repository_name],
-                                    CONF_RO[:repository_base])
-    src = File.expand_path(timestamp_to_pathname(stamp) + '.md', repo_ro_path)
-
-    FileUtils.mkdir_p(File.dirname(dst))
-    FileUtils.copy_file(src, dst)
-    FileUtils.copy_file(src, dst_sfx)
+    setup_read_write_repo(@conf_rw)
   end
 
   def test_it_can_delete_text_in_the_repository

--- a/test/textrepo_file_system_repository_entries_mmdd_test.rb
+++ b/test/textrepo_file_system_repository_entries_mmdd_test.rb
@@ -1,0 +1,22 @@
+require 'test_helper'
+
+# [issue #47]
+class TextrepoFileSystemRepositoryEntriesMmddTest < Minitest::Test
+  def setup
+    @conf_rw = CONF_RW.dup
+    @conf_rw[:repository_name] = "test_repo_entries_mmdd"
+
+    ["2020-11-16 00:00:00", "2020-09-10 11:16:00", "2020-10-11 12:11:16"].each { |t|
+      filename = File.expand_path("#{t.tr('- :', '')}.md", repo_path(@conf_rw))
+      write_text(filename, "text")
+    }
+  end
+
+  def test_it_distinguish_mmdd_pattern_correctly
+    repo = Textrepo::FileSystemRepository.new(@conf_rw)
+    result = repo.entries("1116")
+
+    assert_equal 1, result.size
+    assert_equal "2020-11-16 00:00:00".tr("- :", ""), result[0].to_s
+  end
+end

--- a/test/textrepo_file_system_repository_update_test.rb
+++ b/test/textrepo_file_system_repository_update_test.rb
@@ -7,14 +7,14 @@ class TextrepoFileSystemRepositoryUpdateTest < Minitest::Test
 
     time_of_src = Time.new(2020, 1, 1, 1, 0, 0)
     stmp_src = Textrepo::Timestamp.new(time_of_src)
-    repo_src = File.expand_path(CONF_RO[:repository_name], CONF_RO[:repository_base])
+    repo_src = repo_path(CONF_RO)
     src = File.expand_path(timestamp_to_pathname(stmp_src) + '.md', repo_src)
 
     0.upto(1) { |i|
       time = Time.at(time_of_src.to_i + i)
       stmp = Textrepo::Timestamp.new(time)
       stmp_sfx = Textrepo::Timestamp.new(time, 88)
-      repo = File.expand_path(@conf_rw[:repository_name], @conf_rw[:repository_base])
+      repo = repo_path(@conf_rw)
       dst = File.expand_path(timestamp_to_pathname(stmp) + '.md', repo)
       dst_sfx = File.expand_path(timestamp_to_pathname(stmp_sfx) + '.md', repo)
 


### PR DESCRIPTION
- modify pattern strings to be passed to `Dir.glob`
- add a test to reproduce the symptom
- refactor some tests
- bump version 0.5.6 -> 0.5.7

This will fix #47.