### PR TITLE
fix: Timestamp.parse_s causes a crash

### DIFF
--- a/lib/textrepo/timestamp.rb
+++ b/lib/textrepo/timestamp.rb
@@ -329,11 +329,11 @@ module Textrepo
       # Raises InvalidTimestampStringError if nil was passed as an arguemnt.
 
       def split_stamp(stamp_str)
-        raise InvalidTimestampStringError, stamp_str if stamp_str.nil?
+        raise InvalidTimestampStringError, "(nil)" if stamp_str.nil?
         #    yyyy  mo    dd    hh    mi      ss      sfx
         a = [0..3, 4..5, 6..7, 8..9, 10..11, 12..13, 15..17].map {|r| stamp_str[r]}
         a.delete_at(-1) if a[-1].nil?
-        a
+        a.map{|e| e || "" }
       end
 
       ##
@@ -348,18 +348,15 @@ module Textrepo
       #     parse_s("20201028163529_034") -> Timestamp
 
       def parse_s(stamp_str)
+        raise InvalidTimestampStringError, "(nil)" if stamp_str.nil?
+        raise InvalidTimestampStringError, "(empty string)" if stamp_str.empty?
+        raise InvalidTimestampStringError, stamp_str if stamp_str.size < 14
+
         begin
           ye, mo, da, ho, mi, se, sfx = split_stamp(stamp_str).map(&:to_i)
           Timestamp.new(Time.new(ye, mo, da, ho, mi, se), sfx)
-        rescue InvalidTimestampStringError, ArgumentError => _
-          emsg = if stamp_str.nil?
-            "(nil)"
-          elsif stamp_str.empty?
-            "(empty string)"
-          else
-            stamp_str
-          end
-          raise InvalidTimestampStringError, emsg
+        rescue ArgumentRangeError, ArgumentError => _
+          raise InvalidTimestampStringError, stamp_str
         end
       end
     end

--- a/lib/textrepo/version.rb
+++ b/lib/textrepo/version.rb
@@ -1,3 +1,3 @@
 module Textrepo
-  VERSION = '0.5.7'
+  VERSION = '0.5.8'
 end

--- a/test/textrepo_timestamp_test.rb
+++ b/test/textrepo_timestamp_test.rb
@@ -387,4 +387,27 @@ class TextrepoTimestampTest < Minitest::Test
     assert_equal parts, result
   end
 
+  # issue #49
+  def test_parse_s_raises_when_the_arg_is_too_short
+    ts_year_only = "2021"
+    ts_year_month = "202103"
+    ts_year_date = "20210323"
+    ts_year_date_hour = "2021032315"
+    ts_year_date_hour_min = "202103231536"
+
+    [ts_year_only, ts_year_month, ts_year_date, ts_year_date_hour, ts_year_date_hour_min].each { |ts|
+      assert_raises(Textrepo::InvalidTimestampStringError) {
+        Textrepo::Timestamp.parse_s(ts)
+      }
+    }
+  end
+
+  def test_parse_s_raises_when_the_arg_contains_invalid_suffix
+    assert_raises(Textrepo::InvalidTimestampStringError) {
+      Textrepo::Timestamp.parse_s("20200323161200_-01")
+    }
+  end
+
+  # issue #49 end
+
 end


### PR DESCRIPTION
- re-write conditions for Timestamp.parse_s to raise
- modify Timestamp.split_stamp:
  - fix the error message when nil was passed
  - replace nil to "" (empty string) in its return array
- bump version 0.5.7 -> 0.5.8

The PR will close #49.