### PR TITLE
fix #54: invoke_searcher_for_entries should returns []

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+
+## [0.5.9] - 2021-05-25
+### Fixed
+- Fix issue #54: add check argument in some methods.
 - Fix issue #52: remove trailing spaces.
+
+### Changed
+- Update copyright year in `LICENSE`. (#53)
 - Use GitHub/Actions instead of Travis-CI.
 
 ## [0.5.8] - 2021-03-23

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
-The MIT License (MIT)
+MIT License
 
-Copyright (c) 2020 mnbi
+Copyright (c) 2020, 2021 mnbi
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -9,13 +9,13 @@ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/examples/rbnotes/lib/rbnotes/commands.rb
+++ b/examples/rbnotes/lib/rbnotes/commands.rb
@@ -43,14 +43,8 @@ USAGE
         def execute(_, conf)
           name = conf[:repository_name]
           base = conf[:repository_base]
-          type = conf[:repository_type]
 
-          puts case type
-               when :file_system
-                 "#{base}/#{name}"
-               else
-                 "#{base}/#{name}"
-               end
+          puts "#{base}/#{name}"
         end
       end
 

--- a/examples/rbnotes/lib/rbnotes/commands/import.rb
+++ b/examples/rbnotes/lib/rbnotes/commands/import.rb
@@ -17,7 +17,7 @@ module Rbnotes
           begin
             repo.create(stamp, content)
             break               # success to create a note
-          rescue Textrepo::DuplicateTimestampError => e
+          rescue Textrepo::DuplicateTimestampError => _
             puts "A text with the timestamp [%s] has been already exists" \
                  " in the repository." % stamp
 
@@ -38,7 +38,7 @@ module Rbnotes
               puts "Try to create a note again with a new " \
                    "timestamp [%s]." % stamp
             end
-          rescue Textrepo::EmptyTextError => e
+          rescue Textrepo::EmptyTextError => _
             puts "... aborted."
             puts "The specified file is empyt."
             exit 1              # error

--- a/lib/textrepo/file_system_repository.rb
+++ b/lib/textrepo/file_system_repository.rb
@@ -89,7 +89,7 @@ module Textrepo
       super
       base = conf[:repository_base]
       @name ||= FAVORITE_REPOSITORY_NAME
-      @path = File.expand_path("#{name}", base)
+      @path = File.expand_path(name, base)
       FileUtils.mkdir_p(@path)
       @extname = conf[:default_extname] || FAVORITE_EXTNAME
       @searcher = find_searcher(conf[:searcher])

--- a/lib/textrepo/file_system_repository.rb
+++ b/lib/textrepo/file_system_repository.rb
@@ -181,9 +181,12 @@ module Textrepo
     #     entries(String = nil) -> Array of Timestamp instances
 
     def entries(stamp_pattern = nil)
+      size = stamp_pattern.to_s.size
+      return [] if size > 0 and !(/\A[\d_]+\Z/ === stamp_pattern)
+
       results = []
 
-      case stamp_pattern.to_s.size
+      case size
       when "yyyymoddhhmiss_lll".size
         stamp = Timestamp.parse_s(stamp_pattern)
         if exist?(stamp)
@@ -315,6 +318,7 @@ module Textrepo
     # one file.
 
     def invoke_searcher_for_entries(searcher, pattern, entries)
+      return [] if entries.empty?
       output = []
 
       if entries.size > LIMIT_OF_FILES

--- a/lib/textrepo/version.rb
+++ b/lib/textrepo/version.rb
@@ -1,3 +1,3 @@
 module Textrepo
-  VERSION = '0.5.8'
+  VERSION = '0.5.9'
 end

--- a/test/fake_searcher
+++ b/test/fake_searcher
@@ -1,0 +1,3 @@
+#!/usr/bin/env ruby
+
+puts "fake searcher"

--- a/test/fixtures/setup_test_repo.rb
+++ b/test/fixtures/setup_test_repo.rb
@@ -20,10 +20,6 @@ stamps = []
 
 files.each { |abspath|
   t = stamps.shift
-  yyyy = "%04d" % t.year
-  mm   = "%02d" % t.month
-  dd   = "%02d" % t.day
-  hhmmss = "%02d%02d%02d" % [t.hour, t.min, t.sec]
 
   dirname = File.expand_path(t.strftime("%Y/%m"), repo_path)
   basename = t.strftime("%Y%m%d%H%M%S")

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -53,7 +53,7 @@ def assert_entries_pattern(pattern, num, conf)
   repo = Textrepo::FileSystemRepository.new(conf)
   entries = repo.entries(pattern)
   assert_equal num, entries.size
-  assert entries.reduce(false) {|r, e| r ||= e.to_s.include?(pattern)}
+  assert entries.reduce(false) {|r, e| r || e.to_s.include?(pattern)}
 end
 
 def assert_search(pattern, num, conf)

--- a/test/textrepo_file_system_repository_search_with_invalid_stamp_pattern_test.rb
+++ b/test/textrepo_file_system_repository_search_with_invalid_stamp_pattern_test.rb
@@ -1,0 +1,22 @@
+require 'fileutils'
+require 'test_helper'
+
+class TextrepoFileSystemRepositorySearchWithsInvalidStampPatternTest < Minitest::Test
+  # [issue #54]
+  def test_it_returns_empty_array_when_passed_invalid_pattern
+    conf = CONF_RW.dup
+    conf[:repository_name] = "test_repo_entries_passed_invalid_pattern"
+    conf[:searcher] = File.expand_path("fake_searcher", __dir__)
+    conf[:searcher_options] = []
+
+    repo = Textrepo::FileSystemRepository.new(conf)
+    hoge_path = repo_path(conf) + "/hoge"
+    FileUtils.mkdir_p(hoge_path)
+    File.open(hoge_path + "/hogeboge.md", "w"){|f| f.puts("hoge")}
+
+    invalid_pattern = "hogebo"
+    entries = repo.search("hoge", invalid_pattern)
+
+    assert_empty entries
+  end
+end


### PR DESCRIPTION
- FileSystemRepository#invoke_searcher_for_entries
  - add check whether the passed target is empty or not
- FileSystemRepository#entries
  - add check whether the passed pattern consists of varid characters
- add a test for the issue
- bump version: 0.5.8 -> 0.5.9

This PR will:
- close #53,
- fix #54.