### PR TITLE
fix: accept incomplete timestamp pattern (#56)

### DIFF
--- a/lib/textrepo/file_system_repository.rb
+++ b/lib/textrepo/file_system_repository.rb
@@ -192,7 +192,18 @@ module Textrepo
         if exist?(stamp)
           results << stamp
         end
-      when 0, "yyyymoddhhmiss".size, "yyyymodd".size, "yyyymo".size
+      when 0, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14
+        # 0 <--- ""
+        # 5 <--- "yyyy m" (incomplete)
+        # 6 <--- "yyyy mo"
+        # 7 <--- "yyyy mo d" (incomplete)
+        # 8 <--- "yyyy mo dd"
+        # 9 <--- "yyyy mo dd h" (incomplete)
+        # 10 <-- "yyyy mo dd hh"
+        # 11 <-- "yyyy mo dd hh m" (incomplete)
+        # 12 <-- "yyyy mo dd hh mm"
+        # 13 <-- "yyyy mo dd hh mm s" (incomplete)
+        # 14 <-- "yyyy mo dd hh mm ss"
         results += find_entries("#{stamp_pattern}*")
       when 4                    # "yyyy" or "modd"
         pat = nil

--- a/test/textrepo_file_system_repository_entries_test.rb
+++ b/test/textrepo_file_system_repository_entries_test.rb
@@ -45,4 +45,14 @@ class TextrepoFileSystemRepositoryEntriesTest < Minitest::Test
   def test_it_can_get_a_list_with_a_yyyymo_pattern
     assert_entries_pattern("202001", 8, CONF_RO)
   end
+
+  # [issue #56]
+  def test_it_can_get_a_list_with_a_incomplete_pattern
+    #                                                     size of pattern
+    assert_entries_pattern("20200", 8, CONF_RO)         # 5
+    assert_entries_pattern("2020010", 8, CONF_RO)       # 7
+    assert_entries_pattern("202001010", 8, CONF_RO)     # 9
+    assert_entries_pattern("2020010101", 8, CONF_RO)    # 11
+    assert_entries_pattern("2020010101000", 8, CONF_RO) # 13
+  end
 end


### PR DESCRIPTION
Add sizes of possible incomplete pattern strings to `case` condition.